### PR TITLE
Fixed zero precision formatting (%.0f)

### DIFF
--- a/src/sprintf.js
+++ b/src/sprintf.js
@@ -128,7 +128,7 @@
                     preSubstitution = String( Math.abs( parseInt( parts[i].data ) ) );
                 break;
                 case 'f':
-                    preSubstitution = ( parts[i].precision == false )
+                    preSubstitution = ( parts[i].precision === false )
                                       ? ( String( ( Math.abs( parseFloat( parts[i].data ) ) ) ) )
                                       : ( Math.abs( parseFloat( parts[i].data ) ).toFixed( parts[i].precision ) );
                 break;


### PR DESCRIPTION
Precision “0” was treated as if no precision was specified
