### PR TITLE
Fixed a bug when loading as global function

### DIFF
--- a/src/sprintf.js
+++ b/src/sprintf.js
@@ -30,7 +30,7 @@
     }
     // Global
     else {
-        this.sprintf = definition();
+        this.sprintf = factory();
     }
 }(this, function() {
     var sprintf = function( format ) {


### PR DESCRIPTION
The identifier `definition` is not defined anywhere, thus global include fails with an error.
